### PR TITLE
followup REVERT: Bug 1890370 - Remove libtheora from the tree.

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -160,6 +160,7 @@ media/libopus/.*
 media/libpng/.*
 media/libsoundtouch/.*
 media/libspeex_resampler/.*
+media/libtheora/.*
 media/libvorbis/.*
 media/libvpx/.*
 media/libwebp/.*

--- a/.prettierignore
+++ b/.prettierignore
@@ -1387,6 +1387,7 @@ media/libopus/
 media/libpng/
 media/libsoundtouch/
 media/libspeex_resampler/
+media/libtheora/
 media/libvorbis/
 media/libvpx/
 media/libwebp/


### PR DESCRIPTION
why is GitHub like this